### PR TITLE
Add validation to make projects have a name

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,6 +5,7 @@ class Project < ActiveRecord::Base
   belongs_to :user
   has_many :services
 
+  validates :name, presence: true
   after_initialize :set_default_environment
 
   private


### PR DESCRIPTION
Simple commit, this just adds 

`validates :name, presence: true` to the project.rb model to validate that it was filled out. 

This fixes an annoying bug where you could generate a project without a name 
